### PR TITLE
Fix for `‘__m128’ does not name a type` compile error.

### DIFF
--- a/plays/dllama.yml
+++ b/plays/dllama.yml
@@ -25,6 +25,14 @@
         version: "{{ dllama_version }}"
       become: true
 
+    - name: Fix sgemm.cpp SSE/AVX include guard
+      ansible.builtin.replace:
+        path: "{{ working_dir }}/distributed-llama/src/nn/llamafile/sgemm.cpp"
+        regexp: '^#elif defined\(__AVX2__\)$'
+        replace: '#elif defined(__SSE__) || defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__)'
+        backup: yes
+      become: true
+
     - name: Build distributed-llama.
       community.general.make:
         chdir: "{{ working_dir }}/distributed-llama"


### PR DESCRIPTION
Fixes ‘__m128’ complication error on QEMU "QEMU Virtual CPU version 2.5+" on x86_64:
```
src/nn/llamafile/sgemm.cpp:84:8: error: ‘__m128’ does not name a type; did you mean ‘__int128’?
   84 | inline __m128 add(__m128 x, __m128 y) { return _mm_add_ps(x, y); }
      |        ^~~~~~
      |        __int128
src/nn/llamafile/sgemm.cpp:85:8: error: ‘__m128’ does not name a type; did you mean ‘__int128’?
   85 | inline __m128 sub(__m128 x, __m128 y) { return _mm_sub_ps(x, y); }
      |        ^~~~~~
      |        __int128
src/nn/llamafile/sgemm.cpp:86:8: error: ‘__m128’ does not name a type; did you mean ‘__int128’?
   86 | inline __m128 mul(__m128 x, __m128 y) { return _mm_mul_ps(x, y); }
      |        ^~~~~~
      |        __int128
src/nn/llamafile/sgemm.cpp:169:1: error: inline variables are only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Werror=c++17-extensions]
  169 | inline float hsum(__m128 x) {
      | ^~~~~~
src/nn/llamafile/sgemm.cpp:169:19: error: ‘__m128’ was not declared in this scope; did you mean ‘__int128’?
  169 | inline float hsum(__m128 x) {
      |                   ^~~~~~
      |                   __int128
src/nn/llamafile/sgemm.cpp:217:20: error: ‘__m128’ does not name a type; did you mean ‘__int128’?
  217 | template <> inline __m128 load(const float *p) {
      |                    ^~~~~~
      |                    __int128
cc1plus: all warnings being treated as errors
make: *** [Makefile:55: llamafile-sgemm.o] Error 1
```